### PR TITLE
Use port settings to configure timeout

### DIFF
--- a/doc/rippled-example.cfg
+++ b/doc/rippled-example.cfg
@@ -179,6 +179,11 @@
 #       connections will be refused until other clients disconnect.
 #       Omit or set to 0 to allow unlimited numbers of clients.
 #
+#   rw_timeout = <number>
+#
+#       Optional. An integer timeout (seconds) value for a complete message
+#       to be read or written on this port. Defaults to 30 seconds.
+#
 #   user = <text>
 #   password = <text>
 #

--- a/src/ripple/rpc/impl/ServerHandlerImp.cpp
+++ b/src/ripple/rpc/impl/ServerHandlerImp.cpp
@@ -837,6 +837,7 @@ to_Port(ParsedPort const& parsed, std::ostream& log)
     p.pmd_options = parsed.pmd_options;
     p.ws_queue_limit = parsed.ws_queue_limit;
     p.limit = parsed.limit;
+    p.rw_timeout = parsed.rw_timeout;
 
     return p;
 }

--- a/src/ripple/server/Port.h
+++ b/src/ripple/server/Port.h
@@ -61,6 +61,9 @@ struct Port
     // Websocket disconnects if send queue exceeds this limit
     std::uint16_t ws_queue_limit;
 
+    // timeout for read or write operations
+    std::chrono::seconds rw_timeout = std::chrono::seconds{30};
+
     // Returns `true` if any websocket protocols are specified
     bool websockets() const;
 
@@ -91,6 +94,7 @@ struct ParsedPort
     beast::websocket::permessage_deflate pmd_options;
     int limit = 0;
     std::uint16_t ws_queue_limit;
+    std::chrono::seconds rw_timeout;
 
     boost::optional<boost::asio::ip::address> ip;
     boost::optional<std::uint16_t> port;

--- a/src/ripple/server/impl/Port.cpp
+++ b/src/ripple/server/impl/Port.cpp
@@ -260,6 +260,9 @@ parse_Port (ParsedPort& port, Section const& section, std::ostream& log)
         section.value_or("compress_level", 3);
     port.pmd_options.memLevel =
         section.value_or("memory_level", 4);
+    port.rw_timeout =
+        static_cast<std::chrono::seconds>(
+            section.value_or<std::uint16_t>("rw_timeout", 30));
 }
 
 } // ripple

--- a/src/test/jtx/impl/envconfig.cpp
+++ b/src/test/jtx/impl/envconfig.cpp
@@ -41,11 +41,13 @@ setupConfigForUnitTests (Config& cfg)
     cfg["port_rpc"].set("port", "8081");
     cfg["port_rpc"].set("protocol", "http,ws2");
     cfg["port_rpc"].set("admin", "127.0.0.1");
+    cfg["port_rpc"].set("rw_timeout", "3");
     cfg["server"].append("port_ws");
     cfg["port_ws"].set("ip", "127.0.0.1");
     cfg["port_ws"].set("port", "8082");
     cfg["port_ws"].set("protocol", "ws");
     cfg["port_ws"].set("admin", "127.0.0.1");
+    cfg["port_ws"].set("rw_timeout", "3");
 }
 
 namespace jtx {

--- a/src/test/server/ServerStatus_test.cpp
+++ b/src/test/server/ServerStatus_test.cpp
@@ -78,6 +78,7 @@ class ServerStatus_test :
             (*p)["port_alt"].set("port", "8099");
             (*p)["port_alt"].set("protocol", "http");
             (*p)["port_alt"].set("admin", "127.0.0.1");
+            (*p)["port_alt"].set("rw_timeout", "3");
         }
 
         return p;

--- a/src/test/server/Server_test.cpp
+++ b/src/test/server/Server_test.cpp
@@ -293,6 +293,7 @@ public:
         list.back().ip = boost::asio::ip::address::from_string (
             "127.0.0.1");
         list.back().protocol.insert("http");
+        list.back().rw_timeout = std::chrono::seconds{3};
         s->ports (list);
 
         test_request();
@@ -366,6 +367,7 @@ public:
             list.back().ip = boost::asio::ip::address::from_string (
                 "127.0.0.1");
             list.back().protocol.insert("http");
+            list.back().rw_timeout = std::chrono::seconds{3};
             s->ports (list);
         }
     }


### PR DESCRIPTION
for your consideration -- I verified that this Port change gives is a 3 second timeout value in tests and 30 second otherwise. I'm unsure about the `rw_timeout` name for the setting (naming is hard).